### PR TITLE
Display timestamp of last build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-"name": "feedback",
-"version": "0.0.1",
-"description": "portal for provided feedback to Jenkins jobs",
-"dependencies": {
-"jquery": "2.2.0",
-"lodash": "4.3.0"
-},
-"devDependencies": {
+  "name": "feedback",
+  "version": "0.0.1",
+  "description": "portal for provided feedback to Jenkins jobs",
+  "dependencies": {
+    "jquery": "2.2.0",
+    "lodash": "4.3.0",
+    "moment": "2.14.1"
+  },
+  "devDependencies": {
     "browserify": "13.0.0",
     "browserify-mustache": "0.0.4",
     "del": "2.2.0",
     "gulp": "3.9.1",
     "gulp-browser": "2.0.1"
-},
-"browserify": {
+  },
+  "browserify": {
     "transform": [
-        "browserify-mustache"
+      "browserify-mustache"
     ]
-}
+  }
 }

--- a/src/main/java/com/transficc/tools/feedback/GetLatestJobBuildInformation.java
+++ b/src/main/java/com/transficc/tools/feedback/GetLatestJobBuildInformation.java
@@ -60,6 +60,7 @@ public class GetLatestJobBuildInformation implements Runnable
                                                job.maybeUpdateAndPublish(buildInformation.getRevision(),
                                                                          buildInformation.getJobStatus(),
                                                                          buildInformation.getNumber(),
+                                                                         buildInformation.getTimestamp(),
                                                                          buildInformation.getJobCompletionPercentage(),
                                                                          messageBus,
                                                                          buildInformation.getComments(),

--- a/src/main/java/com/transficc/tools/feedback/JenkinsFacade.java
+++ b/src/main/java/com/transficc/tools/feedback/JenkinsFacade.java
@@ -88,7 +88,7 @@ public class JenkinsFacade
             final String[] comments = new String[commentList.size()];
             commentList.toArray(comments);
             final TestResults testResults = getTestResults(buildDetails);
-            return Result.success(new LatestBuildInformation(revision, jobStatus, buildDetails.getNumber(), jobCompletionPercentage, comments, buildDetails.isBuilding(), testResults));
+            return Result.success(new LatestBuildInformation(revision, jobStatus, buildDetails.getNumber(), buildDetails.getTimestamp(), jobCompletionPercentage, comments, buildDetails.isBuilding(), testResults));
         }
         catch (final IOException e)
         {
@@ -135,16 +135,21 @@ public class JenkinsFacade
         private final String[] comments;
         private final boolean building;
         private final TestResults testResults;
+        private long timestamp;
 
         public LatestBuildInformation(final String revision,
                                       final JobStatus jobStatus,
                                       final int number,
+                                      final long timestamp,
                                       final double jobCompletionPercentage,
-                                      final String[] comments, final boolean building, final TestResults testResults)
+                                      final String[] comments,
+                                      final boolean building,
+                                      final TestResults testResults)
         {
             this.revision = revision;
             this.jobStatus = jobStatus;
             this.number = number;
+            this.timestamp = timestamp;
             this.jobCompletionPercentage = jobCompletionPercentage;
             this.comments = comments;
             this.building = building;
@@ -184,6 +189,11 @@ public class JenkinsFacade
         public TestResults getTestResults()
         {
             return testResults;
+        }
+
+        public long getTimestamp()
+        {
+            return timestamp;
         }
     }
 

--- a/src/main/java/com/transficc/tools/feedback/Job.java
+++ b/src/main/java/com/transficc/tools/feedback/Job.java
@@ -37,6 +37,7 @@ public class Job
     private volatile String[] comments = new String[0];
     private volatile boolean building;
     private volatile TestResults jobsTestResults;
+    private volatile long timestamp;
 
     public Job(final String name, final String url, final int priority, final JobStatus jobStatus, final boolean shouldDisplayCommentsForJob, final VersionControl versionControl)
     {
@@ -51,6 +52,7 @@ public class Job
     public void maybeUpdateAndPublish(final String revision,
                                       final JobStatus jobStatus,
                                       final int buildNumber,
+                                      final long timestamp,
                                       final double jobCompletionPercentage,
                                       final MessageBus messageBus,
                                       final String[] comments,
@@ -63,6 +65,7 @@ public class Job
             this.revision = "".equals(revision) ? this.revision : revision;
             this.jobStatus = jobStatus;
             this.buildNumber = buildNumber;
+            this.timestamp = timestamp;
             this.jobCompletionPercentage = jobCompletionPercentage;
             this.comments = shouldDisplayCommentsForJob ? comments : NO_COMMENTS;
             this.building = building;
@@ -88,7 +91,7 @@ public class Job
     public PublishableJob createPublishable()
     {
         final String revision = getRevision();
-        return new PublishableJob(name, url, priority, revision, jobStatus, buildNumber, jobCompletionPercentage, comments, building, jobsTestResults);
+        return new PublishableJob(name, url, priority, revision, jobStatus, buildNumber, timestamp, jobCompletionPercentage, comments, building, jobsTestResults);
     }
 
     private String getRevision()
@@ -122,6 +125,7 @@ public class Job
                ", revision='" + revision + '\'' +
                ", jobStatus=" + jobStatus +
                ", buildNumber=" + buildNumber +
+               ", timestamp=" + timestamp +
                ", jobCompletionPercentage=" + jobCompletionPercentage +
                ", comments=" + Arrays.toString(comments) +
                '}';

--- a/src/main/java/com/transficc/tools/feedback/messaging/PublishableJob.java
+++ b/src/main/java/com/transficc/tools/feedback/messaging/PublishableJob.java
@@ -27,6 +27,7 @@ public class PublishableJob
     private final String revision;
     private final JobStatus jobStatus;
     private final int buildNumber;
+    private final long timestamp;
     private final double jobCompletionPercentage;
     private final String[] comments;
     private final boolean shouldHideProgressBar;
@@ -40,6 +41,7 @@ public class PublishableJob
                           final String revision,
                           final JobStatus jobStatus,
                           final int buildNumber,
+                          final long timestamp,
                           final double jobCompletionPercentage,
                           final String[] comments,
                           final boolean building,
@@ -51,6 +53,7 @@ public class PublishableJob
         this.revision = revision;
         this.jobStatus = jobStatus;
         this.buildNumber = buildNumber;
+        this.timestamp = timestamp;
         this.jobCompletionPercentage = jobCompletionPercentage;
         this.comments = comments.clone();
         this.shouldHideProgressBar = !building;
@@ -94,6 +97,11 @@ public class PublishableJob
         return buildNumber;
     }
 
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
     public double getJobCompletionPercentage()
     {
         return jobCompletionPercentage;
@@ -129,6 +137,7 @@ public class PublishableJob
                ", revision='" + revision + '\'' +
                ", jobStatus=" + jobStatus +
                ", buildNumber=" + buildNumber +
+               ", timestamp=" + timestamp +
                ", jobCompletionPercentage=" + jobCompletionPercentage +
                ", comments=" + Arrays.toString(comments) +
                ", shouldHideProgressBar=" + shouldHideProgressBar +
@@ -156,6 +165,10 @@ public class PublishableJob
             return false;
         }
         if (buildNumber != that.buildNumber)
+        {
+            return false;
+        }
+        if (timestamp != that.timestamp)
         {
             return false;
         }
@@ -207,6 +220,7 @@ public class PublishableJob
         result = 31 * result + (revision != null ? revision.hashCode() : 0);
         result = 31 * result + (jobStatus != null ? jobStatus.hashCode() : 0);
         result = 31 * result + buildNumber;
+        // TODO: timestamp in hashCode?
         temp = Double.doubleToLongBits(jobCompletionPercentage);
         result = 31 * result + (int)(temp ^ (temp >>> 32));
         result = 31 * result + Arrays.hashCode(comments);

--- a/src/main/resources/static/styling.css
+++ b/src/main/resources/static/styling.css
@@ -14,10 +14,7 @@ body, table {
     font-size: 16px;
     font-family: monospace;
 }
-.job a:link,
-.job a:active,
-.job a:visited,
-.job a:hover {
+.job a {
     color: #000000;
 }
 
@@ -25,8 +22,16 @@ body, table {
     background-color: #33cc33;
 }
 
+.build-status-success a {
+    color: #000000;
+}
+
 .build-status-error {
     background-color: #EE2222;
+}
+
+.build-status-error a {
+    color: #FFF;
 }
 
 .build-status-disabled {

--- a/src/main/resources/templates/index.hbs
+++ b/src/main/resources/templates/index.hbs
@@ -36,7 +36,11 @@
                 {{else}}
                 <div class="col-md-2">
                 {{/if}}
-                <div id="{{name}}" class="job build-status-{{jobStatus}}" data-title="{{name}}" data-job-status="{{jobStatus}}" data-priority="{{priority}}">
+                <div id="{{name}}"
+                     class="job build-status-{{jobStatus}}"
+                     data-title="{{name}}"
+                     data-job-status="{{jobStatus}}"
+                     data-priority="{{priority}}">
                     <div class="row">
                         <div class="col-md-12">
                             <table>
@@ -49,6 +53,7 @@
                                                 <span>Failed: {{jobsTestResults.failCount}}</span>
                                                 <span>Ignored: {{jobsTestResults.skipCount}}</span>
                                         </div>
+                                        <div data-timestamp="{{timestamp}}" class="timestamp"></div>
                                     </td>
                                     <td style="vertical-align:top;">
                                         {{#each comments}}

--- a/src/main/resources/templates/index.hbs
+++ b/src/main/resources/templates/index.hbs
@@ -46,8 +46,8 @@
                             <table>
                                 <tr>
                                     <td style="vertical-align:top;">
-                                        <div><a href="{{url}}{{buildNumber}}">{{revision}}</a></div>
-                                        <div><a href="{{url}}">{{name}}</a></div>
+                                        <div><a target="_blank" href="{{url}}{{buildNumber}}">{{revision}}</a></div>
+                                        <div><a target="_blank" href="{{url}}">{{name}}</a></div>
                                         <div class="test-report" {{#unless jobsTestResults}}hidden{{/unless}}>
                                                 <span>Passed: {{jobsTestResults.passCount}}</span>
                                                 <span>Failed: {{jobsTestResults.failCount}}</span>

--- a/src/main/webapp/app.js
+++ b/src/main/webapp/app.js
@@ -84,7 +84,8 @@ $(document).ready(function() {
 
     function updateTimestamps() {
         $('.timestamp').each(function() {
-            $(this).text(moment($(this).data('timestamp')).fromNow());
+            var timestamp = $(this).data('timestamp');
+            timestamp == 0 ? $(this).text("") : $(this).text(moment(timestamp).fromNow());
         });
     }
 
@@ -147,6 +148,8 @@ $(document).ready(function() {
                             timestamp: job.timestamp
                         }));
 
+            updateTimestamps();
+
             if (dataPriority == 0) {
                 if (currentJobStatus !== 'error' && newJobStatus === 'error') {
                     var firstJob = _.chain($('.job')).
@@ -176,7 +179,6 @@ $(document).ready(function() {
             $('#iteration').html(data.value.iteration);
         } else if (type === 'heartBeat') {
             missedHeartBeats = 0;
-            updateTimestamps();
         }
     }
 

--- a/src/main/webapp/app.js
+++ b/src/main/webapp/app.js
@@ -12,6 +12,7 @@
  */
 var $ = require('jquery');
 var _ = require('lodash');
+var moment = require('moment');
 var jobTemplate = require('./partials/job.mustache');
 window.$ = window.jQuery = $;
 var heartBeatInterval = null;
@@ -81,6 +82,12 @@ $(document).ready(function() {
         }
     }
 
+    function updateTimestamps() {
+        $('.timestamp').each(function() {
+            $(this).text(moment($(this).data('timestamp')).fromNow());
+        });
+    }
+
     function onOpen() {
         if (heartBeatInterval === null) {
             missedHeartBeats = 0;
@@ -136,7 +143,8 @@ $(document).ready(function() {
                             shouldHideTestReport: job.shouldHideTestResults,
                             passCount: !!testResults && testResults.passCount,
                             failCount: !!testResults && testResults.failCount,
-                            skipCount: !!testResults && testResults.skipCount
+                            skipCount: !!testResults && testResults.skipCount,
+                            timestamp: job.timestamp
                         }));
 
             if (dataPriority == 0) {
@@ -168,6 +176,7 @@ $(document).ready(function() {
             $('#iteration').html(data.value.iteration);
         } else if (type === 'heartBeat') {
             missedHeartBeats = 0;
+            updateTimestamps();
         }
     }
 

--- a/src/main/webapp/partials/job.mustache
+++ b/src/main/webapp/partials/job.mustache
@@ -8,8 +8,8 @@
             <table>
                 <tr>
                     <td style="vertical-align:top;">
-                        <div><a href="{{url}}{{buildNumber}}">{{revision}}</a></div>
-                        <div><a href="{{url}}">{{name}}</a></div>
+                        <div><a target="_blank" href="{{url}}{{buildNumber}}">{{revision}}</a></div>
+                        <div><a target="_blank" href="{{url}}">{{name}}</a></div>
                         <div class="test-report" {{#shouldHideTestReport}}hidden{{/shouldHideTestReport}}>
                             <span>Passed: {{passCount}}</span>
                             <span>Failed: {{failCount}}</span>

--- a/src/main/webapp/partials/job.mustache
+++ b/src/main/webapp/partials/job.mustache
@@ -1,4 +1,8 @@
-<div id="{{name}}" class="job build-status-{{jobStatus}}" data-title="{{name}}" data-job-status="{{jobStatus}}" data-priority="{{priority}}">
+<div id="{{name}}"
+     class="job build-status-{{jobStatus}}"
+     data-title="{{name}}"
+     data-job-status="{{jobStatus}}"
+     data-priority="{{priority}}">
     <div class="row">
         <div class="col-md-12">
             <table>
@@ -11,6 +15,7 @@
                             <span>Failed: {{failCount}}</span>
                             <span>Ignored: {{skipCount}}</span>
                         </div>
+                        <div class="timestamp" data-timestamp="{{timestamp}}"></div>
                     </td>
                     <td style="vertical-align:top;">
                         {{#comments}}

--- a/src/test/java/com/transficc/tools/feedback/GetLatestJobBuildInformationTest.java
+++ b/src/test/java/com/transficc/tools/feedback/GetLatestJobBuildInformationTest.java
@@ -88,7 +88,7 @@ public class GetLatestJobBuildInformationTest
                                                       .setField("building", false)
                                                       .setField("changeSet", buildChangeSet)
                                                       .setField("result", BuildResult.SUCCESS)
-                                                      .setField("timestamp", 5)
+                                                      .setField("timestamp", 5l)
                                                       .setField("estimatedDuration", 10)
                                                       .build());
         //when
@@ -98,7 +98,7 @@ public class GetLatestJobBuildInformationTest
         //then
 
         final PublishableJob actualJob = messageBusQueue.take();
-        assertThat(actualJob, is(new PublishableJob(jobName, jobUrl, 0, revision, JenkinsFacade.JobStatus.SUCCESS, 0, 50.0, new String[0], false,
+        assertThat(actualJob, is(new PublishableJob(jobName, jobUrl, 0, revision, JenkinsFacade.JobStatus.SUCCESS, 0, 5l, 50.0, new String[0], false,
                                                     new JenkinsFacade.TestResults(1, 1, 2))));
     }
 

--- a/src/test/java/com/transficc/tools/feedback/JobTest.java
+++ b/src/test/java/com/transficc/tools/feedback/JobTest.java
@@ -40,44 +40,44 @@ public class JobTest
     public void setup()
     {
         MockitoAnnotations.initMocks(this);
-        job.maybeUpdateAndPublish("revision1", JobStatus.SUCCESS, 1, 110, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision1", JobStatus.SUCCESS, 1, 1468934838586L, 110, messageBus, new String[0], false, null);
         verify(messageBus).sendUpdate(any(Job.class));
     }
 
     @Test
     public void shouldNotPublishIfJobHasAlreadyCompleted()
     {
-        job.maybeUpdateAndPublish("revision1", JobStatus.SUCCESS, 1, 1120, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision1", JobStatus.SUCCESS, 1, 1468934838586L, 1120, messageBus, new String[0], false, null);
         verifyNoMoreInteractions(messageBus);
     }
 
     @Test
     public void shouldPublishIfANewRunHasStarted()
     {
-        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 0, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 1468934838586L, 0, messageBus, new String[0], false, null);
         verify(messageBus, times(2)).sendUpdate(job);
     }
 
     @Test
     public void shouldPublishIfAnUpdateForARunIsReceived()
     {
-        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 10, messageBus, new String[0], false, null);
-        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 20, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 1468934838586L, 10, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 1468934838586L, 20, messageBus, new String[0], false, null);
         verify(messageBus, times(3)).sendUpdate(job);
     }
 
     @Test
     public void shouldPublishIfJobCompletes()
     {
-        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 10, messageBus, new String[0], false, null);
-        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 110, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 1468934838586L, 10, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision2", JobStatus.SUCCESS, 2, 1468934838586L, 110, messageBus, new String[0], false, null);
         verify(messageBus, times(3)).sendUpdate(job);
     }
 
     @Test
     public void shouldTruncateGitHashes()
     {
-        job.maybeUpdateAndPublish("revision21", JobStatus.SUCCESS, 2, 0, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision21", JobStatus.SUCCESS, 2, 1468934838586L, 0, messageBus, new String[0], false, null);
 
         final PublishableJob publishable = job.createPublishable();
 
@@ -88,7 +88,7 @@ public class JobTest
     public void shouldNotRuncateRevisionIfVersionControlIsSvn()
     {
         final Job job = new Job("tom", "url", 3, JobStatus.SUCCESS, false, VersionControl.SVN);
-        job.maybeUpdateAndPublish("revision21", JobStatus.SUCCESS, 2, 0, messageBus, new String[0], false, null);
+        job.maybeUpdateAndPublish("revision21", JobStatus.SUCCESS, 2, 1468934838586L, 0, messageBus, new String[0], false, null);
 
         final PublishableJob publishable = job.createPublishable();
 


### PR DESCRIPTION
This is tentative PR for further discussion. There's a few lifecycle things that aren't quite right but I don't fully understand how this is meant to fit together.

Each job update is writing the Jenkins timestamp to the dom and each heartbeat is updating all the timestamp labels to show how long between now and the timestamp. Unfortunately re-rendering job.mustache removes the label until the next heartbeat so the update lifecycle needs some work. Perhaps a more D3-like approach?

Is this useful to you and worth discussing further?
